### PR TITLE
Migrate Tether carpets and add dirty steel tiles

### DIFF
--- a/maps/tether/atoms/areas.dm
+++ b/maps/tether/atoms/areas.dm
@@ -272,7 +272,6 @@
 /area/shuttle/belter/station
 	name = "Belter Shuttle Landed"
 	icon_state = "shuttle2"
-	base_turf = /turf/simulated/floor/tiled/asteroid_steel/airless
 
 /area/shuttle/large_escape_pod1/station
 	icon_state = "shuttle2"

--- a/maps/tether/atoms/turfs.dm
+++ b/maps/tether/atoms/turfs.dm
@@ -80,6 +80,22 @@
 	icon_base = "steel"
 	color = null
 
+/turf/simulated/floor/tiled/steel_dirty
+	name = "steel floor"
+	icon_state = "steel_dirty"
+	initial_flooring = /decl/flooring/tiling/steel_dirty
+
+/obj/item/stack/tile/floor/steel_dirty
+	name = "steel floor tile"
+	singular_name = "steel floor tile"
+	icon_state = "tile_steel"
+	material = /decl/material/solid/metal/plasteel
+
+/decl/flooring/tiling/steel_dirty
+	name = "floor"
+	icon_base = "steel_dirty"
+	build_type = /obj/item/stack/tile/floor/steel_dirty
+
 /turf/simulated/floor/tiled/dark
 	icon_state = "dark"
 	color = null
@@ -98,6 +114,10 @@
 	icon = 'icons/turf/flooring/wood.dmi'
 	icon_state = "wood"
 	color = WOOD_COLOR_GENERIC
+
+/turf/simulated/floor/wood/broken/Initialize(ml, floortype)
+	. = ..()
+	break_tile()
 
 //Unsimulated
 /turf/unsimulated/wall/planetary/virgo3b

--- a/maps/tether/atoms/unimplemented/turfs.dm
+++ b/maps/tether/atoms/unimplemented/turfs.dm
@@ -1,14 +1,4 @@
-/turf/simulated/floor/carpet/bcarpet
-/turf/simulated/floor/carpet/oracarpet
-/turf/simulated/floor/carpet/purcarpet
-/turf/simulated/floor/carpet/sblucarpet
-/turf/simulated/floor/carpet/turcarpet
-/turf/simulated/floor/tiled/asteroid_steel/airless
-/turf/simulated/floor/tiled/steel
-/turf/simulated/floor/tiled/steel_dirty
-/turf/simulated/floor/wood/broken
 /turf/space/cracked_asteroid
-/turf/unsimulated/wall/planetary/virgo3b
 /turf/simulated/floor/wood/sif
 /turf/simulated/shuttle/wall/dark
 /turf/simulated/shuttle/wall/dark/hard_corner

--- a/maps/tether/main_dmms/tether-03-surface3.dmm
+++ b/maps/tether/main_dmms/tether-03-surface3.dmm
@@ -2124,7 +2124,7 @@
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "fJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2133,7 +2133,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "fK" = (
 /obj/machinery/power/apc/super,
@@ -2506,7 +2506,7 @@
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "gt" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -4268,7 +4268,7 @@
 	dir = 1
 	},
 /obj/item/chems/condiment/spacespice,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "jk" = (
 /obj/effect/floor_decal/borderfloor/corner{
@@ -4314,7 +4314,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "jn" = (
 /obj/structure/cable/green{
@@ -4324,7 +4324,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "jo" = (
 /obj/structure/reagent_dispensers/cookingoil,
@@ -4337,7 +4337,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "jp" = (
 /obj/machinery/alarm{
@@ -4357,7 +4357,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/dinnerware,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "jr" = (
 /obj/structure/closet/secure_closet/freezer/meat,
@@ -4376,7 +4376,7 @@
 	name = "Chef"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "jt" = (
 /obj/machinery/alarm{
@@ -4692,7 +4692,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "kc" = (
 /obj/structure/cable/green{
@@ -4754,7 +4754,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "kh" = (
 /obj/structure/cable/green{
@@ -4762,14 +4762,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "ki" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "kj" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
@@ -4784,7 +4784,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "kk" = (
 /obj/machinery/camera/network/tether{
@@ -5163,7 +5163,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "kP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5177,7 +5177,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "kQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -5189,14 +5189,14 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "kR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "kS" = (
 /turf/simulated/wall,
@@ -5482,18 +5482,18 @@
 /obj/item/chems/condiment/enzyme,
 /obj/item/chems/dropper,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "lu" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "lv" = (
 /obj/machinery/appliance/grill,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "lw" = (
 /obj/structure/grille,
@@ -5778,7 +5778,7 @@
 /obj/item/kitchen/rollingpin,
 /obj/item/knife/kitchen/cleaver,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "mg" = (
 /obj/machinery/icecream_vat,
@@ -5789,13 +5789,13 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "mi" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table,
 /obj/machinery/microwave,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "mj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5809,7 +5809,7 @@
 	name = "Chef"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "mk" = (
 /obj/structure/table,
@@ -5819,7 +5819,7 @@
 	},
 /obj/item/book/manual/chef_recipes,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "ml" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6065,14 +6065,14 @@
 	pixel_x = 5
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "mJ" = (
 /obj/machinery/appliance/mixer/cereal,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "mK" = (
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -6080,7 +6080,7 @@
 	dir = 8
 	},
 /obj/structure/table,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "mL" = (
 /obj/structure/table/marble,
@@ -6091,7 +6091,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "mM" = (
 /obj/effect/floor_decal/spline/plain{
@@ -6400,7 +6400,7 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/atrium_three)
 "no" = (
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "np" = (
 /obj/abstract/landmark/start{
@@ -6423,7 +6423,7 @@
 /area/hydroponics)
 "nq" = (
 /obj/machinery/computer/modular/preset/civilian,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "nr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6434,7 +6434,7 @@
 /area/tether/surfacebase/atrium_three)
 "ns" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "nt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7040,7 +7040,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "oN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7059,7 +7059,7 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "oO" = (
 /obj/structure/flora/bush/grassybush,
@@ -8327,7 +8327,7 @@
 "qW" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "qX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8537,7 +8537,7 @@
 	name = "Garden"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "ru" = (
 /turf/simulated/wall,
@@ -9033,7 +9033,7 @@
 	dir = 10
 	},
 /obj/machinery/appliance/cooker/oven,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "so" = (
 /obj/effect/floor_decal/borderfloor,
@@ -9842,7 +9842,7 @@
 	name = "Kitchen"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "tR" = (
 /obj/machinery/firealarm{
@@ -10020,7 +10020,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "uk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10047,7 +10047,7 @@
 /obj/effect/floor_decal/spline/plain,
 /obj/structure/table/marble,
 /obj/effect/floor_decal/borderfloor,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "un" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10063,7 +10063,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "uo" = (
 /obj/structure/table/reinforced,
@@ -10075,7 +10075,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "up" = (
 /obj/structure/grille,
@@ -10385,11 +10385,11 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "uR" = (
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "uS" = (
 /obj/structure/table/marble,
@@ -10399,20 +10399,20 @@
 /obj/item/chems/condiment/small/saltshaker{
 	pixel_x = -3
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "uT" = (
 /obj/machinery/camera/network/civilian{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "uU" = (
 /obj/structure/table/bench/padded,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "uV" = (
 /obj/structure/table/steel,
@@ -10683,17 +10683,17 @@
 /area/crew_quarters/bar)
 "vq" = (
 /obj/structure/table/bench/padded,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "vr" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "vs" = (
 /obj/effect/floor_decal/borderfloor,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "vt" = (
 /obj/structure/disposalpipe/segment{
@@ -10868,12 +10868,12 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "vO" = (
 /obj/structure/table/marble,
 /obj/item/bell,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "vP" = (
 /obj/effect/floor_decal/borderfloor{
@@ -11799,7 +11799,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "xy" = (
 /obj/structure/disposalpipe/segment,
@@ -12102,7 +12102,7 @@
 	name = "Bar Shutters"
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "xZ" = (
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -12113,7 +12113,7 @@
 	name = "Kitchen Shutters"
 	},
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "ya" = (
 /turf/simulated/floor/tiled,
@@ -15394,7 +15394,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "Dx" = (
 /turf/simulated/wall/r_wall,
@@ -15455,7 +15455,7 @@
 "DC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "DD" = (
 /obj/structure/disposalpipe/segment{
@@ -15721,7 +15721,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "DR" = (
 /obj/structure/bed/chair/office/dark,
@@ -16264,7 +16264,7 @@
 /area/assembly/robotics)
 "EF" = (
 /obj/item/stool/padded,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/bar)
 "EG" = (
 /obj/structure/table/reinforced,
@@ -16338,7 +16338,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "EL" = (
 /obj/machinery/alarm{
@@ -16352,7 +16352,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "EM" = (
 /turf/simulated/floor/tiled{
@@ -16523,7 +16523,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "Fc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16536,7 +16536,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "Fd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16643,7 +16643,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "Fk" = (
 /obj/machinery/light{
@@ -16659,7 +16659,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "Fl" = (
 /obj/structure/disposalpipe/segment{
@@ -16692,7 +16692,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "Fn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16959,7 +16959,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "FH" = (
 /obj/machinery/firealarm{
@@ -17015,7 +17015,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "FM" = (
 /obj/structure/hygiene/sink{
@@ -17268,7 +17268,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "Gp" = (
 /obj/structure/table/gamblingtable,
@@ -17958,7 +17958,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "HO" = (
 /obj/effect/decal/cleanable/blood/oil,
@@ -17983,7 +17983,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "HS" = (
 /obj/machinery/camera/network/research,
@@ -17997,7 +17997,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "HT" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -18452,7 +18452,7 @@
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "IM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -19141,7 +19141,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "Ku" = (
 /obj/effect/floor_decal/borderfloor{
@@ -19217,7 +19217,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "KB" = (
 /obj/structure/grille,
@@ -19249,7 +19249,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "KI" = (
 /obj/structure/window/basic{
@@ -19271,7 +19271,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "KK" = (
 /obj/machinery/firealarm{
@@ -19283,7 +19283,7 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "KL" = (
 /obj/structure/cable/green{
@@ -19335,7 +19335,7 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "KP" = (
 /obj/item/stool/padded,
@@ -19384,14 +19384,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "KV" = (
 /obj/machinery/light,
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "KW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -19421,12 +19421,12 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "KZ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/rnd/hallway)
 "La" = (
 /obj/effect/floor_decal/borderfloor{
@@ -19569,7 +19569,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/bar)
 "Lq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -19578,7 +19578,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/bar)
 "Lr" = (
 /obj/structure/table/woodentable,
@@ -19631,7 +19631,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/bar)
 "Lw" = (
 /obj/machinery/light,
@@ -20762,7 +20762,7 @@
 	},
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp/green,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/lounge)
 "Qj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21266,7 +21266,7 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/lounge)
 "Sz" = (
 /obj/machinery/power/apc/super{
@@ -21576,7 +21576,7 @@
 /area/tether/surfacebase/atrium_three)
 "Un" = (
 /obj/machinery/computer/arcade/battle,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/bar)
 "Uo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -21880,7 +21880,7 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/bar)
 "Wf" = (
 /obj/machinery/light{
@@ -21913,7 +21913,7 @@
 "Wn" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp/green,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/lounge)
 "Wo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22105,7 +22105,7 @@
 /area/crew_quarters/bar)
 "XB" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/lounge)
 "XC" = (
 /obj/structure/window/basic{
@@ -22545,7 +22545,7 @@
 /area/tether/surfacebase/public_garden_three)
 "ZR" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/lounge)
 "ZS" = (
 /obj/effect/floor_decal/borderfloor{

--- a/maps/tether/main_dmms/tether-04-transit.dmm
+++ b/maps/tether/main_dmms/tether-04-transit.dmm
@@ -91,7 +91,7 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "ap" = (
 /obj/machinery/vending/coffee,
@@ -115,7 +115,7 @@
 /obj/structure/table/woodentable,
 /obj/machinery/light,
 /obj/structure/flora/pottedplant/small,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "ax" = (
 /turf/simulated/floor/plating,
@@ -125,7 +125,7 @@
 /area/tether/midpoint)
 "az" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "aA" = (
 /obj/structure/disposalpipe/segment{
@@ -147,7 +147,7 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "aC" = (
 /obj/structure/cable,
@@ -212,12 +212,12 @@
 /area/maintenance/tether_midpoint)
 "aL" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "aM" = (
 /obj/structure/table/woodentable,
 /obj/item/dice/d20,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "aN" = (
 /obj/structure/disposalpipe/down{
@@ -269,10 +269,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "aV" = (
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "aW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -335,13 +335,13 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/flower,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "bg" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "bi" = (
 /obj/structure/disposalpipe/segment{
@@ -362,7 +362,7 @@
 "bj" = (
 /obj/structure/table/woodentable,
 /obj/structure/flora/pottedplant/flower,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "bk" = (
 /turf/unsimulated/dark_filler,
@@ -396,7 +396,7 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/small,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "uu" = (
 /obj/structure/cable{
@@ -440,12 +440,12 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "zF" = (
 /obj/structure/table/woodentable,
 /obj/structure/flora/pottedplant/small,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "Aw" = (
 /obj/effect/ceiling,
@@ -457,7 +457,7 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant/flower,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/midpoint)
 "Hs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,

--- a/maps/tether/main_dmms/tether-05-station1.dmm
+++ b/maps/tether/main_dmms/tether-05-station1.dmm
@@ -195,7 +195,7 @@
 /obj/item/chems/drinks/flask{
 	pixel_x = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/captain)
 "aaC" = (
 /obj/machinery/power/grid_checker,
@@ -4198,7 +4198,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "aiT" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -4217,7 +4217,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajb" = (
 /obj/structure/bookcase{
@@ -4263,13 +4263,13 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/super,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajj" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajk" = (
 /obj/structure/cable/green{
@@ -4278,7 +4278,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4337,14 +4337,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajs" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajt" = (
 /obj/structure/grille,
@@ -4393,7 +4393,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajB" = (
 /obj/structure/cable/green{
@@ -4463,7 +4463,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajK" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
@@ -4540,7 +4540,7 @@
 /obj/item/camera/tvcamera,
 /obj/item/camera/tvcamera,
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajV" = (
 /obj/structure/closet,
@@ -4549,7 +4549,7 @@
 /obj/item/pen/invisible,
 /obj/item/pen/invisible,
 /obj/item/pen/invisible,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ajW" = (
 /obj/machinery/newscaster{
@@ -4572,7 +4572,7 @@
 /area/library)
 "akc" = (
 /obj/machinery/vending/snack,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "ake" = (
 /obj/structure/cable/green{
@@ -4705,7 +4705,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "aku" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4718,7 +4718,7 @@
 /obj/machinery/door/morgue{
 	name = "Private Study"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4727,13 +4727,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4747,14 +4747,14 @@
 	pixel_x = 32;
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "aky" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4784,7 +4784,7 @@
 "akE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akF" = (
 /obj/machinery/firealarm{
@@ -4802,15 +4802,15 @@
 	dir = 1
 	},
 /obj/item/taperecorder,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akG" = (
 /obj/machinery/light/small,
 /obj/machinery/vending/cola,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akH" = (
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4922,7 +4922,7 @@
 	pixel_y = -30;
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akV" = (
 /obj/structure/table/woodentable,
@@ -4934,7 +4934,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "akW" = (
 /obj/structure/cable/green{
@@ -13407,7 +13407,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "aQl" = (
 /obj/machinery/power/apc{
@@ -13593,7 +13593,7 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
 "aRX" = (
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "aRZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13646,7 +13646,7 @@
 	name = "CE Office Door Control";
 	pixel_x = 26
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "aSo" = (
 /obj/abstract/landmark/latejoin/cryo,
@@ -13742,7 +13742,7 @@
 /area/crew_quarters/sleep/engi_wash)
 "aTm" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "aTA" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -13854,7 +13854,7 @@
 	},
 /obj/item/folder/yellow,
 /obj/item/pen/multi,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "aTW" = (
 /obj/machinery/alarm{
@@ -14505,7 +14505,7 @@
 	},
 /obj/item/clothing/glasses/welding/superior,
 /obj/item/flashlight/lamp,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "baI" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -14743,7 +14743,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/table/reinforced,
 /obj/item/stamp/ce,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "bcp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14764,7 +14764,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "bcs" = (
 /obj/structure/filing_cabinet/tall,
@@ -14778,7 +14778,7 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "bcx" = (
 /obj/structure/cable/green{
@@ -15597,7 +15597,7 @@
 /area/hallway/station/atrium)
 "bfT" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "bfW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18472,7 +18472,7 @@
 	pixel_x = -22
 	},
 /obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/captain)
 "bFQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18582,7 +18582,7 @@
 /turf/simulated/floor/plating,
 /area/tether/station/dock_two)
 "bGQ" = (
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/captain)
 "bGW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -20208,7 +20208,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/captain)
 "fOH" = (
 /obj/machinery/light{
@@ -20682,7 +20682,7 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/crew_quarters/captain)
 "ksm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -21055,7 +21055,7 @@
 /obj/abstract/landmark/start{
 	name = "Librarian"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "mnV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -21069,7 +21069,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "mtd" = (
 /obj/structure/table/woodentable,
@@ -21960,7 +21960,7 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/library)
 "rCG" = (
 /obj/effect/floor_decal/borderfloor/corner{
@@ -22361,7 +22361,7 @@
 /area/tether/station/explorer_entry)
 "ufh" = (
 /mob/living/simple_animal/hostile/retaliate/parrot/Poly,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "ugd" = (
 /obj/machinery/light{

--- a/maps/tether/main_dmms/tether-06-station2.dmm
+++ b/maps/tether/main_dmms/tether-06-station2.dmm
@@ -2576,7 +2576,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "ew" = (
 /obj/machinery/door/firedoor/glass,
@@ -12369,7 +12369,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/medical/biostorage)
 "xa" = (
 /obj/effect/floor_decal/borderfloor{
@@ -12578,7 +12578,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/medical/biostorage)
 "xv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -12682,7 +12682,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/medical/virologyaccess)
 "xF" = (
 /turf/simulated/wall/r_wall,
@@ -12737,14 +12737,14 @@
 "xL" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "xM" = (
 /obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "xN" = (
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "xO" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -12755,7 +12755,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/medical/biostorage)
 "xP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
@@ -13014,7 +13014,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "yp" = (
 /obj/structure/table/woodentable,
@@ -13022,12 +13022,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "yq" = (
 /obj/structure/table/woodentable,
 /obj/item/folder/red,
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "yr" = (
 /obj/structure/bed/chair/comfy/black{
@@ -13036,7 +13036,7 @@
 /obj/abstract/landmark/start{
 	name = "Command Secretary"
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "ys" = (
 /obj/machinery/camera/network/command{
@@ -13052,7 +13052,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/wrench,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/medical/biostorage)
 "yu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -13296,7 +13296,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "yQ" = (
 /obj/structure/table/woodentable,
@@ -13308,18 +13308,18 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "yR" = (
 /obj/structure/table/woodentable,
 /obj/item/folder/blue,
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "yS" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "yT" = (
 /obj/effect/floor_decal/borderfloor{
@@ -13452,7 +13452,7 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blue3,
 /area/bridge/meeting_room)
 "zd" = (
 /obj/effect/floor_decal/borderfloor{
@@ -15882,7 +15882,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "Hb" = (
 /obj/structure/closet/crate,
@@ -16091,13 +16091,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "IG" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "II" = (
 /obj/structure/sign/warning/nosmoking_2,
@@ -16205,7 +16205,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "Jt" = (
 /obj/structure/table,
@@ -16694,7 +16694,7 @@
 /obj/item/pen/blue,
 /obj/item/pen,
 /obj/item/pen/red,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "LW" = (
 /obj/structure/catwalk,
@@ -17247,7 +17247,7 @@
 	dir = 4
 	},
 /obj/item/paicard,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "Pl" = (
 /obj/structure/cable{
@@ -17378,14 +17378,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "PS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "PV" = (
 /obj/effect/floor_decal/rust,
@@ -17712,7 +17712,7 @@
 	dir = 4
 	},
 /obj/item/folder,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "RQ" = (
 /obj/structure/table/steel,
@@ -17885,7 +17885,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "SW" = (
 /obj/machinery/alarm{
@@ -18099,7 +18099,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "Us" = (
 /obj/machinery/light{
@@ -19062,7 +19062,7 @@
 "ZK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/tether/station/public_meeting_room)
 "ZL" = (
 /obj/effect/floor_decal/rust,

--- a/maps/tether/main_dmms/tether-07-station3.dmm
+++ b/maps/tether/main_dmms/tether-07-station3.dmm
@@ -18219,7 +18219,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "Gc" = (
 /obj/structure/rack,
@@ -18552,9 +18552,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
-"GI" = (
-/turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
 "GJ" = (
 /obj/structure/cable/green{
@@ -19323,7 +19320,7 @@
 "Im" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "In" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -19616,13 +19613,13 @@
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "IS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "IT" = (
 /obj/machinery/button/blast_door{
@@ -20103,13 +20100,13 @@
 "JH" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "JI" = (
 /obj/structure/closet/crate/internals,
 /obj/machinery/light/small,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "JJ" = (
 /obj/machinery/firealarm{
@@ -20117,7 +20114,7 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "JK" = (
 /obj/structure/closet/crate/medical,
@@ -42037,7 +42034,7 @@ FZ
 GG
 GG
 GG
-GI
+GG
 JH
 Fj
 Vj
@@ -42346,7 +42343,7 @@ Dw
 Er
 zK
 Gb
-GI
+GG
 Hx
 Io
 GG

--- a/maps/tether/main_dmms/tether-09-solars.dmm
+++ b/maps/tether/main_dmms/tether-09-solars.dmm
@@ -816,7 +816,7 @@
 	name = "west bump";
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva_storage)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -826,7 +826,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva_storage)
 "ca" = (
 /obj/structure/window/reinforced/full,
@@ -890,7 +890,7 @@
 	id_tag = "scioutpost_airlock_inner";
 	locked = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva)
 "ch" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -900,7 +900,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva_storage)
 "ci" = (
 /obj/machinery/door/airlock/external/glass{
@@ -908,7 +908,7 @@
 	locked = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva)
 "cj" = (
 /obj/structure/disposalpipe/segment{
@@ -1050,7 +1050,7 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/machinery/camera/network/research_outpost,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cx" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1081,7 +1081,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1099,7 +1099,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cz" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1121,7 +1121,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cA" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1146,7 +1146,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cB" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1165,7 +1165,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cC" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1190,7 +1190,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cD" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1218,7 +1218,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cE" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1242,7 +1242,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1260,7 +1260,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -1406,7 +1406,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "cR" = (
 /obj/structure/disposalpipe/segment{
@@ -1424,7 +1424,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "cS" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1445,7 +1445,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cT" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1467,7 +1467,7 @@
 	name = " Western Outpost Hallway"
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "cU" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1485,7 +1485,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cV" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1504,7 +1504,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cW" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1531,7 +1531,7 @@
 	name = "south bump";
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cY" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1554,7 +1554,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "cZ" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1577,7 +1577,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "da" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1598,7 +1598,7 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "db" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1619,7 +1619,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "dc" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1635,7 +1635,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "dd" = (
 /obj/structure/cable/heavyduty{
@@ -1796,7 +1796,7 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "ds" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1827,7 +1827,7 @@
 	dir = 8;
 	light_range = 12
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "dt" = (
 /obj/structure/window/reinforced/full,
@@ -1858,7 +1858,7 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "dG" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -2026,7 +2026,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "dU" = (
 /obj/structure/window/reinforced/full,
@@ -2061,7 +2061,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "ef" = (
 /obj/structure/window/reinforced/full,
@@ -2202,7 +2202,7 @@
 	dir = 4;
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "eC" = (
 /obj/structure/fence/post{
@@ -2326,7 +2326,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "eR" = (
 /obj/effect/floor_decal/borderfloor{
@@ -2348,7 +2348,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "eU" = (
 /turf/simulated/wall/r_wall,
@@ -2458,7 +2458,7 @@
 	name = "east bump";
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "fs" = (
 /obj/effect/floor_decal/borderfloor{
@@ -2485,7 +2485,7 @@
 	dir = 8;
 	pixel_x = -26
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "ft" = (
 /obj/machinery/camera/network/research_outpost{
@@ -2526,7 +2526,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "fD" = (
 /obj/structure/disposalpipe/segment,
@@ -2628,7 +2628,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "fL" = (
 /obj/effect/floor_decal/borderfloor{
@@ -2652,7 +2652,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "fN" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -2696,7 +2696,7 @@
 	name = "east bump";
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "fU" = (
 /obj/effect/floor_decal/borderfloor{
@@ -2822,7 +2822,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "gt" = (
 /obj/structure/sign/department/science_1{
@@ -2835,7 +2835,7 @@
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gw" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -2849,20 +2849,20 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gx" = (
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gz" = (
 /obj/machinery/computer/telescience,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gC" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -2874,7 +2874,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gH" = (
 /obj/effect/floor_decal/borderfloor{
@@ -2896,7 +2896,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "gI" = (
 /obj/structure/cable/green{
@@ -2953,7 +2953,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "gL" = (
 /obj/structure/cable/green{
@@ -2964,7 +2964,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gM" = (
 /obj/structure/cable/green{
@@ -2985,7 +2985,7 @@
 	name = "Telescience Lab"
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gO" = (
 /obj/structure/cable/green{
@@ -2999,20 +2999,20 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gQ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gU" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "gX" = (
 /obj/structure/window/reinforced/full,
@@ -3033,7 +3033,7 @@
 /obj/item/gps/science,
 /obj/item/gps/science,
 /obj/item/gps/science,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hb" = (
 /obj/effect/floor_decal/borderfloor{
@@ -3058,7 +3058,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "hd" = (
 /obj/effect/floor_decal/borderfloor{
@@ -3082,7 +3082,7 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "he" = (
 /obj/effect/floor_decal/borderfloor,
@@ -3122,7 +3122,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "hh" = (
 /obj/structure/disposalpipe/segment,
@@ -3147,7 +3147,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "hi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3174,7 +3174,7 @@
 	name = "Telescience Lab"
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3184,7 +3184,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3193,7 +3193,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3202,7 +3202,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "ho" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3211,7 +3211,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3220,7 +3220,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3232,13 +3232,13 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3247,7 +3247,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3264,7 +3264,7 @@
 /obj/item/folder/red{
 	pixel_x = -4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hx" = (
 /obj/effect/floor_decal/borderfloor{
@@ -3288,7 +3288,7 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "hz" = (
 /obj/structure/disposalpipe/segment{
@@ -3317,7 +3317,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "hC" = (
 /obj/structure/disposalpipe/segment{
@@ -3347,11 +3347,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "hG" = (
 /obj/structure/table,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -3366,11 +3366,11 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hI" = (
 /obj/structure/closet/l3closet/scientist,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3379,14 +3379,14 @@
 /obj/structure/table,
 /obj/item/stock_parts/circuitboard/telesci_pad,
 /obj/item/stack/cable_coil/black,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hK" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/network/research_outpost{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hL" = (
 /obj/structure/cable/green,
@@ -3394,7 +3394,7 @@
 	name = "south bump";
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3403,7 +3403,7 @@
 /obj/structure/table,
 /obj/item/multitool,
 /obj/item/screwdriver,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "hR" = (
 /obj/effect/floor_decal/borderfloor{
@@ -3423,7 +3423,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "hS" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -3460,7 +3460,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "hV" = (
 /obj/structure/flora/sif/tendrils,
@@ -3488,7 +3488,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "im" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -3527,7 +3527,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "iL" = (
 /obj/structure/window/reinforced/full,
@@ -3554,7 +3554,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "je" = (
 /obj/effect/floor_decal/borderfloor{
@@ -3571,7 +3571,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "jg" = (
 /obj/effect/floor_decal/borderfloor{
@@ -3590,7 +3590,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "ji" = (
 /obj/effect/floor_decal/borderfloor/corner{
@@ -3608,7 +3608,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "jj" = (
 /obj/effect/floor_decal/borderfloor{
@@ -3627,7 +3627,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "jk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -3635,7 +3635,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "jl" = (
 /obj/structure/disposalpipe/segment{
@@ -3662,7 +3662,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "jn" = (
 /obj/structure/disposalpipe/segment{
@@ -3684,7 +3684,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "jq" = (
 /obj/structure/disposalpipe/segment{
@@ -3714,7 +3714,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "jr" = (
 /obj/structure/disposalpipe/segment{
@@ -3743,7 +3743,7 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "jt" = (
 /obj/effect/floor_decal/borderfloor,
@@ -3761,7 +3761,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "ju" = (
 /obj/effect/floor_decal/borderfloor{
@@ -3779,7 +3779,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "jy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3891,7 +3891,7 @@
 	pixel_x = 26;
 	pixel_y = -4
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "kk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -3921,7 +3921,7 @@
 "kl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/bed/sofa/left/red,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "km" = (
 /obj/effect/floor_decal/borderfloor,
@@ -3941,7 +3941,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "kq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3979,7 +3979,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "kv" = (
 /obj/effect/floor_decal/borderfloor{
@@ -4003,7 +4003,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "kA" = (
 /obj/structure/window/reinforced/full,
@@ -4042,7 +4042,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "kD" = (
 /obj/effect/floor_decal/borderfloor{
@@ -4057,7 +4057,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "kF" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -4182,7 +4182,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "lp" = (
 /obj/structure/disposalpipe/segment,
@@ -4206,12 +4206,12 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "lq" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/rd,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "lu" = (
 /obj/machinery/hologram/holopad,
@@ -4246,7 +4246,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "lz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4344,7 +4344,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "ma" = (
 /obj/effect/floor_decal/borderfloor{
@@ -4376,7 +4376,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "mc" = (
 /obj/structure/hygiene/shower{
@@ -4433,7 +4433,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "mh" = (
 /obj/structure/closet/radiation,
@@ -4464,7 +4464,7 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "mn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4478,7 +4478,7 @@
 	pixel_x = 26;
 	pixel_y = -4
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "mw" = (
 /obj/machinery/atmospherics/valve{
@@ -4487,7 +4487,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "mA" = (
 /obj/structure/grille,
@@ -4544,7 +4544,7 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Science Outpost Substation"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/substation)
 "mM" = (
 /obj/structure/railing/mapped{
@@ -4589,7 +4589,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "mS" = (
 /obj/structure/disposalpipe/segment{
@@ -4674,7 +4674,7 @@
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "nG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4714,7 +4714,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "nQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4767,7 +4767,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "oe" = (
 /obj/effect/floor_decal/borderfloor{
@@ -4823,7 +4823,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
@@ -4862,7 +4862,7 @@
 	pixel_x = 27;
 	pixel_y = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva)
 "oN" = (
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -4899,7 +4899,7 @@
 	dir = 8;
 	pixel_y = -4
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "oW" = (
 /obj/effect/floor_decal/borderfloor,
@@ -4919,7 +4919,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "pc" = (
 /obj/machinery/portable_atmospherics/powered/pump,
@@ -4928,7 +4928,7 @@
 "pi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/sofa/right/red,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "pk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -5022,7 +5022,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "pR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -5052,7 +5052,7 @@
 	name = "Eastern Outpost Hallway"
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "pV" = (
 /obj/machinery/washing_machine,
@@ -5118,7 +5118,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "qh" = (
 /obj/effect/floor_decal/borderfloor{
@@ -5141,7 +5141,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "qk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5157,7 +5157,7 @@
 /area/outpost/research/crew_quarters/showers)
 "qn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "qq" = (
 /obj/structure/cable/green{
@@ -5185,7 +5185,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "qG" = (
 /obj/machinery/atmospherics/unary/tank/air,
@@ -5217,7 +5217,7 @@
 /obj/effect/floor_decal/corner/mauve/bordercorner2{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "qJ" = (
 /obj/structure/sign/warning/secure_area,
@@ -5228,7 +5228,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "qP" = (
 /obj/structure/hygiene/toilet{
@@ -5272,7 +5272,7 @@
 	dir = 8;
 	pixel_x = -26
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "qV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5362,7 +5362,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "rC" = (
 /obj/machinery/door/blast/regular{
@@ -5418,7 +5418,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "rI" = (
 /obj/effect/floor_decal/rust,
@@ -5448,7 +5448,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "rP" = (
 /turf/simulated/floor/carpet/blue,
@@ -5471,7 +5471,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "sb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5495,7 +5495,7 @@
 /area/outpost/research/longtermstorage)
 "se" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "sj" = (
 /obj/effect/floor_decal/borderfloor{
@@ -5504,7 +5504,7 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva_storage)
 "sk" = (
 /obj/structure/disposalpipe/segment{
@@ -5584,7 +5584,7 @@
 	name = "west bump";
 	pixel_x = -22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "sH" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -5615,7 +5615,7 @@
 	name = "south bump";
 	pixel_y = -22
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "sN" = (
 /obj/machinery/door/blast/regular{
@@ -5647,7 +5647,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "sR" = (
 /obj/structure/disposalpipe/segment{
@@ -5665,7 +5665,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "sW" = (
 /turf/simulated/wall,
@@ -5685,7 +5685,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "tc" = (
 /obj/structure/cable/green{
@@ -5769,7 +5769,7 @@
 "tz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/sofa/right/red,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "tA" = (
 /obj/structure/hygiene/toilet{
@@ -5821,7 +5821,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "tK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5835,7 +5835,7 @@
 	},
 /obj/structure/table/woodentable,
 /obj/item/storage/box/donkpockets,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "tM" = (
 /obj/structure/disposalpipe/segment,
@@ -5850,7 +5850,7 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "tT" = (
 /obj/machinery/vending/snack,
@@ -5876,7 +5876,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "tX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -5904,7 +5904,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/longtermstorage)
 "ud" = (
 /obj/effect/floor_decal/borderfloor{
@@ -5915,7 +5915,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "uf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -5934,7 +5934,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "ul" = (
 /obj/effect/floor_decal/borderfloor{
@@ -5994,7 +5994,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "ux" = (
 /obj/effect/floor_decal/borderfloor{
@@ -6010,7 +6010,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "uz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6047,7 +6047,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "uH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
@@ -6107,7 +6107,7 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "vm" = (
 /obj/machinery/door/airlock{
@@ -6120,7 +6120,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "vp" = (
 /obj/effect/floor_decal/rust,
@@ -6226,7 +6226,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "wu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6246,7 +6246,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "wv" = (
 /obj/machinery/vending/tool,
@@ -6256,7 +6256,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "wx" = (
 /obj/effect/floor_decal/borderfloor{
@@ -6266,7 +6266,7 @@
 /obj/item/clothing/suit/storage/toggle/wintercoat,
 /obj/item/clothing/mask/gas,
 /obj/item/tank/emergency/oxygen/engi,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva_storage)
 "wy" = (
 /obj/structure/closet/radiation,
@@ -6398,7 +6398,7 @@
 "xr" = (
 /obj/item/bedsheet/ian,
 /obj/structure/bed/padded,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "xs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -6450,7 +6450,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "xO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -6483,7 +6483,7 @@
 	dir = 10
 	},
 /obj/machinery/timeclock/premade/north,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "xU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6504,7 +6504,7 @@
 /area/outpost/research/toxins_misc_lab)
 "xY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "yc" = (
 /obj/structure/railing/mapped{
@@ -6575,7 +6575,7 @@
 	dir = 6
 	},
 /obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "ys" = (
 /obj/structure/table,
@@ -6614,7 +6614,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "yB" = (
 /obj/effect/floor_decal/borderfloor{
@@ -6628,7 +6628,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "yF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6677,7 +6677,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "yY" = (
 /obj/effect/floor_decal/rust,
@@ -6702,7 +6702,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "ze" = (
 /obj/effect/floor_decal/borderfloor{
@@ -6718,7 +6718,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "zf" = (
 /obj/effect/floor_decal/borderfloor{
@@ -6743,7 +6743,7 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "zg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6755,7 +6755,7 @@
 	},
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "zj" = (
 /obj/structure/hygiene/toilet,
@@ -6808,7 +6808,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "zt" = (
 /obj/structure/disposalpipe/segment,
@@ -6830,11 +6830,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "zu" = (
 /obj/item/frame,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "zE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -6874,7 +6874,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "zK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6935,7 +6935,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "zX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6984,7 +6984,7 @@
 /obj/machinery/door/airlock/double/glass{
 	name = "Southern Outpost Hallway"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "Ag" = (
 /obj/machinery/disposal,
@@ -7096,7 +7096,7 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "AF" = (
 /turf/simulated/wall/r_lead,
@@ -7113,7 +7113,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "AI" = (
 /obj/effect/floor_decal/borderfloor{
@@ -7134,7 +7134,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "AP" = (
 /obj/structure/table/bench/padded,
@@ -7229,7 +7229,7 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "Bj" = (
 /turf/simulated/floor/tiled/white,
@@ -7242,7 +7242,7 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "Bs" = (
 /obj/effect/floor_decal/borderfloor{
@@ -7257,7 +7257,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "Bv" = (
 /obj/effect/floor_decal/borderfloor{
@@ -7337,7 +7337,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7345,7 +7345,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "BK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7354,7 +7354,7 @@
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva_storage)
 "BQ" = (
 /obj/structure/disposalpipe/segment{
@@ -7414,7 +7414,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "CC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7426,7 +7426,7 @@
 	},
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "CI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7448,7 +7448,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "CU" = (
 /obj/structure/disposalpipe/segment,
@@ -7473,7 +7473,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "CV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -7492,7 +7492,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "Db" = (
 /obj/effect/floor_decal/borderfloor{
@@ -7535,7 +7535,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "Dm" = (
 /obj/structure/disposalpipe/segment,
@@ -7564,7 +7564,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "Do" = (
 /obj/structure/table,
@@ -7612,7 +7612,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "DK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7659,14 +7659,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "DR" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "DV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7734,7 +7734,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "EB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7746,7 +7746,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "EE" = (
 /obj/effect/floor_decal/borderfloor/corner{
@@ -7809,7 +7809,7 @@
 	},
 /obj/structure/table/woodentable,
 /obj/item/storage/box/donkpockets,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "EU" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -7823,7 +7823,7 @@
 /turf/simulated/floor/plating,
 /area/outpost/research/atmospherics)
 "Fe" = (
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "Fp" = (
 /obj/structure/disposalpipe/segment{
@@ -7865,7 +7865,7 @@
 /obj/effect/floor_decal/corner/mauve/bordercorner2{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "FJ" = (
 /obj/structure/table,
@@ -7962,7 +7962,7 @@
 	name = "north bump";
 	pixel_y = 22
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "Gt" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -8008,7 +8008,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "GT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8038,7 +8038,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "Hi" = (
 /obj/machinery/hologram/holopad,
@@ -8139,7 +8139,7 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "HC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8191,7 +8191,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "HO" = (
 /obj/structure/disposalpipe/segment{
@@ -8220,7 +8220,7 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "HP" = (
 /obj/structure/disposalpipe/segment{
@@ -8238,7 +8238,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "HR" = (
 /obj/machinery/door/airlock/external/glass{
@@ -8294,7 +8294,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "Ig" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -8315,7 +8315,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva_storage)
 "Ih" = (
 /turf/simulated/wall,
@@ -8360,7 +8360,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "IQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
@@ -8379,7 +8379,7 @@
 	name = "south bump";
 	pixel_y = -22
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8438,7 +8438,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "Js" = (
 /obj/structure/disposalpipe/segment{
@@ -8570,7 +8570,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "Ki" = (
 /obj/effect/floor_decal/borderfloor{
@@ -8598,7 +8598,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "Kl" = (
 /obj/effect/floor_decal/borderfloor{
@@ -8619,7 +8619,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "Km" = (
 /obj/effect/floor_decal/borderfloor{
@@ -8678,7 +8678,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "Kx" = (
 /obj/effect/floor_decal/borderfloor{
@@ -8706,7 +8706,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "KE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8754,7 +8754,7 @@
 	dir = 9
 	},
 /obj/structure/bed/chair/comfy/purple,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "KV" = (
 /obj/effect/floor_decal/borderfloor{
@@ -8770,7 +8770,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "KW" = (
 /obj/structure/cable/green{
@@ -8838,7 +8838,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "Lo" = (
 /obj/structure/window/reinforced/full,
@@ -8890,7 +8890,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "Lz" = (
 /turf/simulated/wall,
@@ -8924,7 +8924,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/research/crew_quarters/sleep/Dorm_1)
 "LO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8946,7 +8946,7 @@
 /obj/structure/bed/chair/comfy/purple{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "LW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8958,7 +8958,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "Ma" = (
 /obj/structure/disposalpipe/segment,
@@ -9054,14 +9054,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/crew_quarters/sleep/Dorm_2)
 "Mw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "MB" = (
 /obj/structure/cable/heavyduty,
@@ -9093,7 +9093,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "MF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -9114,7 +9114,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "MR" = (
 /obj/structure/cable/green{
@@ -9149,7 +9149,7 @@
 	dir = 8;
 	pixel_x = -26
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "MW" = (
 /obj/structure/disposalpipe/segment{
@@ -9204,7 +9204,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "Nm" = (
 /obj/structure/disposalpipe/segment{
@@ -9228,7 +9228,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "No" = (
 /obj/effect/floor_decal/borderfloor{
@@ -9242,7 +9242,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "Np" = (
 /obj/effect/floor_decal/borderfloor,
@@ -9352,7 +9352,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "NV" = (
 /obj/structure/hygiene/sink{
@@ -9429,7 +9429,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "Ow" = (
 /obj/structure/window/reinforced,
@@ -9495,7 +9495,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "OY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9574,7 +9574,7 @@
 /turf/simulated/floor/plating,
 /area/outpost/research/longtermstorage)
 "PC" = (
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "PO" = (
 /obj/machinery/meter,
@@ -9596,7 +9596,7 @@
 /obj/item/clothing/suit/storage/toggle/wintercoat,
 /obj/item/clothing/mask/gas,
 /obj/item/tank/emergency/oxygen/engi,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva_storage)
 "Qi" = (
 /obj/structure/sign/warning/nosmoking_1,
@@ -9680,7 +9680,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "QH" = (
 /obj/machinery/light,
@@ -9691,7 +9691,7 @@
 "QI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/bed/sofa/left/red,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "QN" = (
 /obj/structure/fence/post{
@@ -9759,7 +9759,7 @@
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/timeclock/premade/north,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "Rq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9767,7 +9767,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "Rs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9848,7 +9848,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "RO" = (
 /obj/effect/floor_decal/borderfloor{
@@ -9862,7 +9862,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "RQ" = (
 /obj/structure/cable/green{
@@ -9940,7 +9940,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "Sq" = (
 /obj/machinery/power/sensor{
@@ -9987,7 +9987,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/rnd/breakroom/outpost)
 "Sz" = (
 /obj/structure/window/reinforced/full,
@@ -10013,7 +10013,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "SB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10060,7 +10060,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "SW" = (
 /obj/effect/floor_decal/industrial/warning/cee,
@@ -10097,7 +10097,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "Tk" = (
 /obj/structure/disposalpipe/segment{
@@ -10126,7 +10126,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "Tq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10327,7 +10327,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_northern_hallway)
 "UG" = (
 /obj/structure/cable{
@@ -10360,7 +10360,7 @@
 /obj/machinery/door/airlock/double/glass{
 	name = "Southern Outpost Hallway"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "UK" = (
 /obj/effect/floor_decal/borderfloor/corner{
@@ -10379,7 +10379,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "UL" = (
 /obj/structure/table,
@@ -10484,7 +10484,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "VD" = (
 /obj/structure/cable/green{
@@ -10573,20 +10573,20 @@
 	id_tag = "scioutpost_airlock_outer";
 	locked = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva)
 "Wg" = (
 /obj/machinery/vending/assist,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "Wh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "Wm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -10599,7 +10599,7 @@
 	output_tag = "burn_ts_out";
 	pressure_setting = 0
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "Ws" = (
 /obj/structure/table/marble,
@@ -10657,7 +10657,7 @@
 /area/outpost/research/storage/surface_eva)
 "Wy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "Wz" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -10708,7 +10708,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_eastern_hallway)
 "WM" = (
 /obj/effect/floor_decal/borderfloor,
@@ -10716,7 +10716,7 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /obj/item/chems/glass/bucket,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "WO" = (
 /obj/structure/window/reinforced/full,
@@ -10755,7 +10755,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "WT" = (
 /obj/structure/sign/warning/radioactive,
@@ -10775,7 +10775,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_storage_hallway)
 "Xh" = (
 /turf/simulated/floor/plating,
@@ -10820,7 +10820,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/tools)
 "XH" = (
 /turf/simulated/wall,
@@ -10842,7 +10842,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/carpet/orange,
 /area/outpost/research/crew_quarters/sleep/Dorm_3)
 "XU" = (
 /obj/structure/disposalpipe/segment{
@@ -10896,7 +10896,7 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_southern_hallway)
 "Yc" = (
 /obj/effect/floor_decal/rust,
@@ -10939,7 +10939,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/telescience_lab)
 "Yn" = (
 /obj/effect/floor_decal/borderfloor{
@@ -10991,7 +10991,7 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/structure/flora/pottedplant/unusual,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/storage/surface_eva_storage)
 "YH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -11071,7 +11071,7 @@
 /obj/effect/floor_decal/corner/mauve/bordercorner2{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/outpost/research/hallway/resarch_outpost_western_hallway)
 "Zy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,

--- a/maps/tether/submaps/admin_use/spa.dmm
+++ b/maps/tether/submaps/admin_use/spa.dmm
@@ -205,7 +205,7 @@
 /area/submap/spa)
 "aI" = (
 /obj/machinery/door/airlock/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/spa)
 "aJ" = (
 /obj/machinery/door/airlock/double/glass,
@@ -259,7 +259,7 @@
 "aU" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/blue,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "aV" = (
 /obj/structure/table/woodentable,
@@ -272,22 +272,22 @@
 	pixel_x = 26;
 	id_tag = "spadorm1"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "aW" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/greendouble,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "aX" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/purple,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "aY" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/red,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "aZ" = (
 /turf/simulated/floor/tiled/white,
@@ -317,9 +317,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/submap/spa)
-"be" = (
-/turf/simulated/floor/carpet/bcarpet,
-/area/submap/spa)
 "bf" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light{
@@ -331,7 +328,7 @@
 	pixel_x = -26;
 	id_tag = "spadorm3"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bg" = (
 /obj/structure/hygiene/sink{
@@ -368,7 +365,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bm" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -407,7 +404,7 @@
 "br" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/brown,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bs" = (
 /obj/structure/table/woodentable,
@@ -420,22 +417,22 @@
 	pixel_x = 26;
 	id_tag = "spadorm5"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bt" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/orange,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bu" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/rainbowdouble,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bv" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/yellow,
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bw" = (
 /obj/structure/hygiene/toilet{
@@ -484,7 +481,7 @@
 	pixel_x = -26;
 	id_tag = "spadorm7"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bD" = (
 /obj/machinery/light{
@@ -563,7 +560,7 @@
 	pixel_x = 26;
 	id_tag = "spadorm2"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bQ" = (
 /obj/structure/table/woodentable,
@@ -573,7 +570,7 @@
 	pixel_x = -26;
 	id_tag = "spadorm4"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bR" = (
 /obj/structure/table/woodentable,
@@ -583,7 +580,7 @@
 	pixel_x = 26;
 	id_tag = "spadorm6"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bS" = (
 /obj/structure/table/woodentable,
@@ -593,7 +590,7 @@
 	pixel_x = -26;
 	id_tag = "spadorm8"
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blue,
 /area/submap/spa)
 "bT" = (
 /obj/machinery/door/airlock{
@@ -1403,7 +1400,7 @@ ae
 aQ
 ab
 aU
-be
+bX
 ab
 bl
 br
@@ -1450,9 +1447,9 @@ ae
 bz
 ab
 aV
-be
+bX
 ab
-be
+bX
 bP
 bx
 bV
@@ -1638,9 +1635,9 @@ ae
 aQ
 ab
 bf
-be
+bX
 ab
-be
+bX
 bQ
 bx
 bV
@@ -1685,7 +1682,7 @@ ae
 aO
 ab
 aW
-be
+bX
 ab
 bl
 bt
@@ -1779,7 +1776,7 @@ ae
 bz
 ab
 aX
-be
+bX
 ab
 bl
 bu
@@ -1826,9 +1823,9 @@ ae
 aQ
 ab
 bs
-be
+bX
 ab
-be
+bX
 bR
 bx
 bV
@@ -2014,9 +2011,9 @@ ae
 bA
 ab
 bC
-be
+bX
 ab
-be
+bX
 bS
 bx
 bV
@@ -2061,7 +2058,7 @@ ae
 bB
 ab
 aY
-be
+bX
 ab
 bl
 bv

--- a/maps/tether/submaps/aerostat/submaps/Blackshuttledown.dmm
+++ b/maps/tether/submaps/aerostat/submaps/Blackshuttledown.dmm
@@ -53,7 +53,7 @@
 	id_tag = "merc_shuttle_outer";
 	name = "Ship External Access"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "am" = (
 /obj/structure/shuttle/engine/heater{
@@ -85,31 +85,31 @@
 /obj/item/clothing/suit/space,
 /obj/item/clothing/suit/space,
 /obj/item/clothing/suit/space,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "ap" = (
 /obj/structure/tank_rack/oxygen,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aq" = (
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "ar" = (
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "as" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "at" = (
 /obj/machinery/fabricator/bioprinter,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "au" = (
 /turf/exterior/barren,
@@ -121,21 +121,21 @@
 "av" = (
 /obj/structure/table/steel,
 /obj/item/gun/projectile/automatic/smg,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aw" = (
 /obj/machinery/door/airlock/external,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "ax" = (
 /obj/machinery/optable,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "ay" = (
 /obj/machinery/bodyscanner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "az" = (
 /turf/exterior/barren,
@@ -148,17 +148,17 @@
 /obj/machinery/computer/modular/preset/cardslot/command{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aB" = (
 /mob/living/simple_mob/mechanical/viscerator,
 /mob/living/simple_mob/mechanical/viscerator,
 /mob/living/simple_mob/mechanical/viscerator,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aD" = (
 /mob/living/simple_mob/humanoid/merc/ranged/space,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aE" = (
 /obj/machinery/light{
@@ -166,85 +166,85 @@
 	icon_state = "tube1";
 	pixel_x = 0
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aF" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aG" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aH" = (
 /obj/structure/table,
 /obj/item/tank/anesthetic,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aI" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/sterile,
 /obj/item/clothing/gloves/sterile,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aJ" = (
 /obj/structure/table,
 /obj/item/chems/spray/sterilizine,
 /obj/item/chems/spray/sterilizine,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aK" = (
 /obj/structure/table,
 /obj/item/storage/box/masks,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aL" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aM" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aN" = (
 /obj/machinery/door/airlock/security{
 	locked = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aO" = (
 /obj/machinery/door/airlock/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aP" = (
 /obj/machinery/power/apc/hyper,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aQ" = (
 /obj/machinery/computer/area_atmos{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aR" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aS" = (
 /obj/structure/table/steel,
 /obj/item/knife,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aU" = (
 /obj/structure/table/steel,
 /obj/random/toolbox,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aV" = (
 /obj/structure/table/steel,
@@ -252,7 +252,7 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aW" = (
 /obj/structure/grille,
@@ -269,7 +269,7 @@
 /area/submap/virgo2/Blackshuttledown)
 "aX" = (
 /obj/item/stool,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "aY" = (
 /obj/structure/grille,
@@ -284,11 +284,11 @@
 "aZ" = (
 /obj/structure/table/steel,
 /obj/item/pizzabox,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "ba" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bb" = (
 /obj/structure/grille,
@@ -307,24 +307,24 @@
 	info = "We need to take a short stop. The engine's are in need of minor repairs due to turbulence, should be a week's time. We've got reserve food supplies but pleanty of locale fauna to subsist on too if need be. PCRC is keeping most of there assets near New Reykjavik and locale authorities are more mindful then most to travel in this kind of weather. Our outfit should be at the rendezvous point in less then ten days assuming the upper ecehelon hasn't dropped ties with us yet.";
 	name = "Operation Progress/M-53"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bf" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bg" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bh" = (
 /obj/structure/closet/toolcloset,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bi" = (
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bj" = (
 /obj/machinery/atmospherics/unary/tank/oxygen,
@@ -332,20 +332,20 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bk" = (
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bm" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bn" = (
 /mob/living/simple_mob/mechanical/viscerator,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bo" = (
 /obj/structure/table/steel,
@@ -354,30 +354,30 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bp" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/structure/bed,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bq" = (
 /mob/living/simple_mob/mechanical/viscerator,
 /mob/living/simple_mob/mechanical/viscerator,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "br" = (
 /obj/structure/table/steel,
 /obj/item/gun/projectile/pistol,
 /obj/item/gun/projectile/shotgun/pump,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bs" = (
 /obj/structure/hygiene/toilet{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bt" = (
 /obj/machinery/light,
@@ -390,19 +390,19 @@
 /obj/item/clothing/suit/space,
 /obj/item/clothing/suit/space,
 /obj/item/clothing/suit/space,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bu" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "bv" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/item/toy/plushie/spider,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/submap/virgo2/Blackshuttledown)
 "by" = (
 /obj/structure/table/steel,

--- a/maps/tether/submaps/aerostat/submaps/Manor1.dmm
+++ b/maps/tether/submaps/aerostat/submaps/Manor1.dmm
@@ -72,13 +72,6 @@
 /obj/structure/hygiene/sink,
 /turf/simulated/wall/virgo2,
 /area/submap/virgo2/Manor1)
-"aq" = (
-/turf/simulated/floor/carpet/bcarpet,
-/area/submap/virgo2/Manor1)
-"ar" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/bcarpet,
-/area/submap/virgo2/Manor1)
 "as" = (
 /obj/structure/door/wood,
 /turf/simulated/floor/holofloor/wood,
@@ -183,7 +176,7 @@
 /turf/simulated/floor/holofloor/wood,
 /area/submap/virgo2/Manor1)
 "aQ" = (
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/submap/virgo2/Manor1)
 "aR" = (
 /obj/structure/table,
@@ -442,7 +435,7 @@
 /area/submap/virgo2/Manor1)
 "bN" = (
 /obj/structure/door/wood,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/submap/virgo2/Manor1)
 "bO" = (
 /obj/machinery/icecream_vat,
@@ -471,7 +464,7 @@
 /area/submap/virgo2/Manor1)
 "bU" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/submap/virgo2/Manor1)
 "bV" = (
 /turf/simulated/floor/holofloor/wood{
@@ -559,7 +552,7 @@
 /turf/simulated/floor/holofloor/wood,
 /area/submap/virgo2/Manor1)
 "cl" = (
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/floor/carpet/blue2,
 /area/submap/virgo2/Manor1)
 "cm" = (
 /obj/effect/decal/cleanable/blood,
@@ -593,7 +586,7 @@
 "cr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/submap/virgo2/Manor1)
 "cs" = (
 /obj/item/twohanded/spear,
@@ -711,7 +704,7 @@
 /area/template_noop)
 "cO" = (
 /obj/machinery/door/airlock/external,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/submap/virgo2/Manor1)
 "kI" = (
 /obj/tether_away_spawner/aerostat_surface,
@@ -719,11 +712,11 @@
 /area/submap/virgo2/Manor1)
 "KY" = (
 /obj/tether_away_spawner/aerostat_surface,
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/floor/carpet/blue2,
 /area/submap/virgo2/Manor1)
 "VR" = (
 /obj/tether_away_spawner/aerostat_surface,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/purple,
 /area/submap/virgo2/Manor1)
 
 (1,1,1) = {"
@@ -1236,32 +1229,32 @@ aa
 aa
 ab
 ag
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-ar
-ar
-ar
-ar
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bP
+bP
+bP
+bP
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
 as
 cw
 ab
@@ -1278,8 +1271,8 @@ aa
 aa
 ab
 ag
-aq
-aq
+bl
+bl
 ag
 ag
 ag
@@ -1320,8 +1313,8 @@ aa
 aa
 ab
 ag
-aq
-aq
+bl
+bl
 ag
 ab
 ab
@@ -1362,8 +1355,8 @@ aa
 aa
 ab
 al
-aq
-aq
+bl
+bl
 az
 ab
 aF
@@ -1404,8 +1397,8 @@ aa
 aa
 ab
 am
-ar
-aq
+bP
+bl
 al
 ab
 aG
@@ -1446,8 +1439,8 @@ aa
 aa
 ab
 al
-ar
-aq
+bP
+bl
 al
 ab
 ag
@@ -1488,8 +1481,8 @@ aa
 aa
 ab
 ag
-ar
-aq
+bP
+bl
 ag
 ab
 al
@@ -1530,8 +1523,8 @@ aa
 aa
 ab
 an
-ar
-ar
+bP
+bP
 an
 ab
 aH
@@ -1572,8 +1565,8 @@ aa
 ab
 ab
 an
-ar
-ar
+bP
+bP
 an
 ab
 ab
@@ -1614,8 +1607,8 @@ ab
 ab
 ag
 ag
-ar
-ar
+bP
+bP
 an
 ab
 aI
@@ -1656,8 +1649,8 @@ ac
 ad
 ag
 ag
-ar
-ar
+bP
+bP
 aA
 ab
 aJ
@@ -1698,8 +1691,8 @@ ac
 ae
 ag
 ag
-aq
-ar
+bl
+bP
 aA
 ab
 aJ
@@ -1740,8 +1733,8 @@ ac
 af
 ag
 ag
-ar
-ar
+bP
+bP
 aA
 ab
 ag
@@ -1782,8 +1775,8 @@ ac
 ag
 ag
 an
-ar
-ar
+bP
+bP
 ag
 ab
 ag
@@ -1824,8 +1817,8 @@ ab
 ah
 ag
 an
-ar
-ar
+bP
+bP
 an
 ab
 aL
@@ -1866,8 +1859,8 @@ ab
 ai
 ag
 an
-ar
-ar
+bP
+bP
 an
 ab
 aL
@@ -1908,8 +1901,8 @@ ac
 ag
 ag
 an
-ar
-ar
+bP
+bP
 ag
 ab
 ag
@@ -1950,8 +1943,8 @@ ac
 ad
 ag
 ag
-ar
-ar
+bP
+bP
 ag
 ab
 ag
@@ -1992,8 +1985,8 @@ ac
 aj
 ag
 ag
-ar
-ar
+bP
+bP
 ag
 ab
 ag
@@ -2034,8 +2027,8 @@ ac
 af
 ag
 ag
-aq
-ar
+bl
+bP
 ag
 ab
 ag
@@ -2076,8 +2069,8 @@ ab
 ab
 ag
 ag
-aq
-aq
+bl
+bl
 ag
 ab
 ah
@@ -2118,8 +2111,8 @@ aa
 ab
 ab
 ag
-aq
-aq
+bl
+bl
 ag
 ab
 ab
@@ -2160,8 +2153,8 @@ aa
 aa
 ab
 ag
-aq
-aq
+bl
+bl
 ag
 ab
 ag
@@ -2202,8 +2195,8 @@ aa
 aa
 ab
 ag
-aq
-aq
+bl
+bl
 ag
 ab
 ag
@@ -2244,8 +2237,8 @@ aa
 aa
 ab
 ag
-aq
-aq
+bl
+bl
 ag
 ab
 ag
@@ -2286,8 +2279,8 @@ aa
 aa
 ab
 al
-aq
-aq
+bl
+bl
 al
 ab
 ag
@@ -2328,8 +2321,8 @@ aa
 aa
 ab
 al
-aq
-aq
+bl
+bl
 al
 ab
 ag
@@ -2370,8 +2363,8 @@ aa
 aa
 ab
 al
-aq
-aq
+bl
+bl
 aC
 ab
 aN
@@ -2412,8 +2405,8 @@ aa
 aa
 ab
 ag
-aq
-aq
+bl
+bl
 ag
 ab
 ab
@@ -2454,8 +2447,8 @@ aa
 aa
 ab
 ag
-aq
-aq
+bl
+bl
 ag
 ag
 ag
@@ -2496,32 +2489,32 @@ aa
 aa
 ab
 ag
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
+bl
 as
 ag
 cl

--- a/maps/tether/submaps/gateway/snow_outpost.dmm
+++ b/maps/tether/submaps/gateway/snow_outpost.dmm
@@ -1057,14 +1057,14 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "dU" = (
 /obj/structure/tank_rack/oxygen,
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "dV" = (
 /obj/machinery/door/airlock/external{
@@ -1072,7 +1072,7 @@
 	id_tag = "merc_shuttle_outer";
 	name = "Ship External Access"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "dW" = (
 /obj/effect/floor_decal/corner/green/border{
@@ -1118,7 +1118,7 @@
 /turf/simulated/floor/tiled/white,
 /area/awaymission/snow_outpost/restricted)
 "eb" = (
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark5";
 	name = "Unknown Shuttle"
@@ -1136,17 +1136,17 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "ef" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eg" = (
 /obj/machinery/door/airlock/external,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eh" = (
 /obj/effect/floor_decal/corner/green/border{
@@ -1175,14 +1175,14 @@
 /turf/simulated/floor/tiled/white,
 /area/awaymission/snow_outpost/restricted)
 "em" = (
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark9";
 	name = "Unknown Shuttle"
 	},
 /area/awaymission/snow_outpost/restricted)
 "en" = (
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark6";
 	name = "Unknown Shuttle"
@@ -1206,19 +1206,19 @@
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "er" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "es" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "et" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -1243,7 +1243,7 @@
 "ew" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/borderfloor/full,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "ex" = (
 /obj/structure/table/steel,
@@ -1252,11 +1252,11 @@
 /area/awaymission/snow_outpost/restricted)
 "ey" = (
 /obj/effect/floor_decal/borderfloor/corner,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "ez" = (
 /obj/effect/floor_decal/borderfloor,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eA" = (
 /obj/machinery/light{
@@ -1267,7 +1267,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eB" = (
 /obj/structure/table,
@@ -1319,7 +1319,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eI" = (
 /obj/structure/bed/chair/office/dark{
@@ -1328,20 +1328,20 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eJ" = (
 /obj/machinery/door/airlock/security{
 	locked = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eK" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/white,
 /area/awaymission/snow_outpost/restricted)
 "eL" = (
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /turf/simulated/shuttle/wall/dark{
 	icon_state = "dark10";
 	name = "Unknown Shuttle"
@@ -1352,41 +1352,41 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eN" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eP" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eQ" = (
 /obj/structure/table/steel,
 /obj/item/knife,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eR" = (
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eS" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eT" = (
 /mob/living/simple_mob/humanoid/merc/ranged/smg/poi,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eU" = (
 /obj/structure/table/steel,
@@ -1419,7 +1419,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eY" = (
 /obj/machinery/light{
@@ -1429,7 +1429,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "eZ" = (
 /mob/living/simple_animal/giant_spider/ion,
@@ -1446,11 +1446,11 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fb" = (
 /obj/item/stool,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fc" = (
 /obj/structure/table/steel,
@@ -1475,39 +1475,39 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fg" = (
 /obj/effect/floor_decal/corner/grey,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fh" = (
 /obj/machinery/door/airlock/glass,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fi" = (
 /obj/structure/table/steel,
 /obj/item/pizzabox,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fj" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fk" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fl" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/floor_decal/borderfloor,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fm" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fn" = (
 /obj/structure/grille,
@@ -1537,20 +1537,20 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fr" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /mob/living/simple_mob/humanoid/merc/ranged/laser/poi,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fs" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "ft" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1559,7 +1559,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fu" = (
 /obj/structure/table/steel,
@@ -1567,16 +1567,16 @@
 	info = "We need to take a short stop. The engine's are in need of minor repairs due to turbulence, should be a week's time. We've got reserve food supplies but pleanty of locale fauna to subsist on too if need be. PCRC is keeping most of there assets near New Reykjavik and locale authorities are more mindful then most to travel in this kind of weather. Our outfit should be at the rendezvous point in less then ten days assuming the upper ecehelon hasn't dropped ties with us yet.";
 	name = "Operation Progress/M-53"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fv" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fw" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fx" = (
 /obj/structure/closet/toolcloset,
@@ -1602,14 +1602,14 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fB" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fC" = (
 /obj/structure/table/steel,
@@ -1622,7 +1622,7 @@
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fE" = (
 /obj/machinery/light{
@@ -1633,12 +1633,12 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fF" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fG" = (
 /obj/machinery/door/airlock,
@@ -1664,13 +1664,13 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fL" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/structure/bed,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fM" = (
 /obj/machinery/light/small{
@@ -1694,7 +1694,7 @@
 	dir = 4
 	},
 /mob/living/simple_mob/humanoid/merc/melee/sword/poi,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fQ" = (
 /obj/structure/hygiene/toilet{
@@ -1716,25 +1716,25 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fS" = (
 /obj/structure/tank_rack/oxygen,
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fT" = (
 /obj/structure/table/woodentable,
 /obj/random/projectile,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fU" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "fV" = (
 /obj/tether_away_spawner/aerostat_inside,
@@ -2548,13 +2548,13 @@
 /area/awaymission/snow_outpost/outpost)
 "iS" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "iT" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/item/toy/plushie/spider,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snow_outpost/restricted)
 "iU" = (
 /turf/simulated/floor/snow/snow2,

--- a/maps/tether/submaps/gateway/snowfield.dmm
+++ b/maps/tether/submaps/gateway/snowfield.dmm
@@ -234,11 +234,11 @@
 "aJ" = (
 /obj/structure/closet/jcloset,
 /obj/item/soap,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snowfield/base)
 "aL" = (
 /obj/structure/closet/l3closet/janitor,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snowfield/base)
 "aM" = (
 /obj/structure/closet/crate/hydroponics/prespawned,
@@ -353,7 +353,7 @@
 /turf/simulated/floor/tiled/white,
 /area/awaymission/snowfield/base)
 "ba" = (
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snowfield/base)
 "bb" = (
 /obj/effect/floor_decal/corner/green{
@@ -382,7 +382,7 @@
 /area/awaymission/snowfield/base)
 "bg" = (
 /obj/machinery/space_heater,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snowfield/base)
 "bh" = (
 /obj/effect/floor_decal/corner/green/full,
@@ -449,7 +449,7 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
 /obj/item/chems/spray/cleaner,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snowfield/base)
 "bo" = (
 /obj/machinery/door/window/northright{
@@ -537,7 +537,7 @@
 /area/awaymission/snowfield/base)
 "by" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snowfield/base)
 "bz" = (
 /obj/machinery/light{
@@ -650,11 +650,11 @@
 /obj/item/mop,
 /obj/item/chems/glass/bucket,
 /obj/structure/janitorialcart,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snowfield/base)
 "bO" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snowfield/base)
 "bP" = (
 /obj/machinery/portable_atmospherics/hydroponics{
@@ -700,7 +700,7 @@
 /area/awaymission/snowfield/base)
 "bU" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/snowfield/base)
 "bV" = (
 /obj/machinery/gateway{

--- a/maps/tether/submaps/gateway/zoo.dmm
+++ b/maps/tether/submaps/gateway/zoo.dmm
@@ -1944,12 +1944,9 @@
 	icon_state = "floor7"
 	},
 /area/awaymission/zoo/tradeship)
-"fP" = (
-/turf/simulated/floor/tiled/steel,
-/area/awaymission/zoo/pirateship)
 "fQ" = (
 /obj/item/stool,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "fR" = (
 /obj/structure/table/reinforced,
@@ -1957,18 +1954,18 @@
 	info = "DEAR DAIRY: So we was doing our typpical route when the captain says we've been picking up weird signals on some backwatter planet. Madsen wanted to stay on course but he ain't the captain, so we went out of the way to check it out. There was lots of rocks on the way, but we got to the planet fine. Found a big fancy camp with nobody around and this big metal donut thing with NT stamps all over it right in the middle. Case of beer too. Captain reckons we can pass it off to some buyer in the Syndicate. Ingram says it's bad luck and that someone is going to come look for it but it sounds like better money than selling bad meat to jerky companies.";
 	name = "Old Diary"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "fS" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/red,
 /obj/item/chems/drinks/bottle/small/beer,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "fT" = (
 /obj/structure/closet,
 /obj/item/clothing/under/overalls,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "fU" = (
 /obj/structure/window/reinforced{
@@ -2042,7 +2039,7 @@
 /area/awaymission/zoo/pirateship)
 "gf" = (
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gg" = (
 /obj/structure/window/reinforced{
@@ -2114,18 +2111,18 @@
 /area/awaymission/zoo/pirateship)
 "go" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gp" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/item/storage/wallet/random,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gq" = (
 /obj/structure/closet,
 /obj/item/clothing/under/lawyer/bluesuit,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gr" = (
 /turf/simulated/shuttle/wall/dark/hard_corner,
@@ -2250,17 +2247,13 @@
 "gJ" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled/steel,
-/area/awaymission/zoo/pirateship)
-"gK" = (
-/obj/structure/door/shuttle,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gL" = (
 /obj/structure/mirror{
 	pixel_y = 28
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gM" = (
 /obj/structure/hygiene/toilet{
@@ -2269,7 +2262,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gN" = (
 /turf/simulated/floor/shuttle/darkred,
@@ -2299,17 +2292,17 @@
 /obj/structure/closet/crate,
 /obj/item/cash/c10,
 /obj/item/cash/c200,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gU" = (
 /obj/structure/closet/crate,
 /obj/item/cash/c10,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gV" = (
 /obj/structure/closet/crate,
 /obj/item/cash/c1000,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gW" = (
 /obj/structure/hygiene/sink{
@@ -2318,7 +2311,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled,
 /area/awaymission/zoo/pirateship)
 "gX" = (
 /obj/machinery/door/airlock/external{
@@ -21774,11 +21767,11 @@ bT
 cp
 fA
 ad
-fP
+bO
 gf
 fQ
-fP
-fP
+bO
+bO
 gT
 ad
 ae
@@ -22081,11 +22074,11 @@ bT
 bT
 bT
 ad
-fP
-fP
-fP
-fP
-fP
+bO
+bO
+bO
+bO
+bO
 gU
 ad
 af
@@ -22388,11 +22381,11 @@ fg
 bT
 bT
 fM
-fP
-fP
-fP
-fP
-fP
+bO
+bO
+bO
+bO
+bO
 gV
 ad
 gb
@@ -22695,12 +22688,12 @@ fh
 bT
 bT
 ad
-fP
-fP
+bO
+bO
 go
-fP
+bO
 gJ
-fP
+bO
 ad
 ad
 ak
@@ -23002,12 +22995,12 @@ fh
 bT
 bT
 ad
-fP
-fP
-fP
-fP
-fP
-fP
+bO
+bO
+bO
+bO
+bO
+bO
 ad
 hk
 al
@@ -23309,12 +23302,12 @@ fi
 bT
 bT
 fM
-fP
-fP
+bO
+bO
 gp
-fP
+bO
 go
-fP
+bO
 hd
 al
 hr
@@ -23617,11 +23610,11 @@ bT
 fB
 ad
 fQ
-fP
-fP
-fP
-fP
-fP
+bO
+bO
+bO
+bO
+bO
 ad
 hl
 ad
@@ -23924,11 +23917,11 @@ fv
 fC
 ad
 fR
-fP
+bO
 go
-fP
+bO
 go
-fP
+bO
 ad
 ad
 ad
@@ -24231,11 +24224,11 @@ ad
 ad
 ad
 fS
-fP
-fP
-fP
-fP
-fP
+bO
+bO
+bO
+bO
+bO
 ad
 ad
 ad
@@ -24537,11 +24530,11 @@ cu
 cu
 cu
 ad
-fP
-fP
-fP
+bO
+bO
+bO
 ad
-gK
+ck
 ad
 ad
 ad
@@ -24844,9 +24837,9 @@ bO
 bO
 bO
 ck
-fP
-fP
-fP
+bO
+bO
+bO
 ad
 gL
 gW
@@ -25152,7 +25145,7 @@ bO
 bO
 ad
 fT
-fP
+bO
 gq
 ad
 gM

--- a/maps/tether/submaps/tether_misc.dmm
+++ b/maps/tether/submaps/tether_misc.dmm
@@ -1889,7 +1889,7 @@
 	pixel_y = -5
 	},
 /obj/item/storage/box/syringes,
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -1952,7 +1952,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -1960,7 +1960,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -1973,7 +1973,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2071,7 +2071,7 @@
 	pixel_x = -12;
 	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2085,7 +2085,7 @@
 /obj/structure/table/steel,
 /obj/item/tank/oxygen,
 /obj/item/tank/oxygen,
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2097,7 +2097,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2184,14 +2184,14 @@
 	dir = 8
 	},
 /obj/structure/iv_drip,
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
 "Az" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2244,7 +2244,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2320,7 +2320,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2404,7 +2404,7 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2464,7 +2464,7 @@
 	},
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2480,7 +2480,7 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2522,7 +2522,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2595,7 +2595,7 @@
 "QH" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/optable,
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2616,7 +2616,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2637,7 +2637,7 @@
 /area/holodeck/holodorm/source_phoron)
 "Tz" = (
 /obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2660,13 +2660,13 @@
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
 "Uq" = (
 /obj/effect/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)
@@ -2684,7 +2684,7 @@
 /obj/effect/floor_decal/corner/red/border,
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/steel{
+/turf/simulated/floor/tiled{
 	initial_gas = list(/decl/material/gas/oxygen = 410)
 	},
 /area/holodeck/holodorm/source_zaddat)

--- a/tools/map_migrations/28_repath_carpets_steel_tile.txt
+++ b/tools/map_migrations/28_repath_carpets_steel_tile.txt
@@ -1,0 +1,7 @@
+# Pull Request 28: Repath some turf types
+/turf/simulated/floor/carpet/bcarpet : /turf/simulated/floor/carpet/blue{@OLD}
+/turf/simulated/floor/carpet/oracarpet : /turf/simulated/floor/carpet/orange{@OLD}
+/turf/simulated/floor/carpet/purcarpet : /turf/simulated/floor/carpet/purple{@OLD}
+/turf/simulated/floor/carpet/sblucarpet : /turf/simulated/floor/carpet/blue3{@OLD}
+/turf/simulated/floor/carpet/turcarpet : /turf/simulated/floor/carpet/blue2{@OLD}
+/turf/simulated/floor/tiled/steel : /turf/simulated/floor/tiled{@OLD}


### PR DESCRIPTION
## Description of changes
Migrates Tether carpet paths to the corresponding-ish Nebula ones.
Adds proper icons and such for the steel_dirty floor type.

## Why and what will this PR improve
Down to only 7 unimplemented turfs.

## Authorship
Taken from an old revision of Citadel Station 13 RP.