### PR TITLE
Fix Tether power consumption

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -89,8 +89,8 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 // These balance how easy or hard it is to create huge pressure gradients with pumps and filters.
 // Lower values means it takes longer to create large pressures differences.
 // Has no effect on pumping gasses from high pressure to low, only from low to high.
-#define ATMOS_PUMP_EFFICIENCY   2.5
-#define ATMOS_FILTER_EFFICIENCY 2.5
+#define ATMOS_PUMP_EFFICIENCY   5
+#define ATMOS_FILTER_EFFICIENCY 5
 
 // Will not bother pumping or filtering if the gas source as fewer than this amount of moles, to help with performance.
 #define MINIMUM_MOLES_TO_PUMP   0.01

--- a/code/game/objects/items/weapons/circuitboards/machinery/portable_atmospherics.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/portable_atmospherics.dm
@@ -15,6 +15,22 @@
 		/obj/item/cell = 1
 	)
 
+/obj/item/stock_parts/circuitboard/portable_scrubber/huge
+	name = "circuitboard (huge scrubber)"
+	board_type = "machine"
+	build_path = /obj/machinery/portable_atmospherics/powered/scrubber/huge
+	origin_tech = @'{"engineering":4,"powerstorage":4}'
+	req_components = list(
+		/obj/item/stock_parts/capacitor = 2,
+		/obj/item/stock_parts/matter_bin = 2,
+		/obj/item/pipe = 2)
+	additional_spawn_components = list(
+		/obj/item/stock_parts/console_screen = 1,
+		/obj/item/stock_parts/keyboard = 1,
+		/obj/item/stock_parts/power/apc/buildable = 1,
+		/obj/item/cell = 1
+	)
+
 /obj/item/stock_parts/circuitboard/portable_scrubber/pump
 	name = "circuitboard (portable pump)"
 	board_type = "machine"

--- a/code/modules/atmospherics/components/binary_devices/algae_generator.dm
+++ b/code/modules/atmospherics/components/binary_devices/algae_generator.dm
@@ -89,7 +89,7 @@
 		storage_capacity[/decl/material/solid/graphite] - stored_material[/decl/material/solid/graphite])
 
 	// STEP 2 - Take the CO2 out of the input!
-	var/power_draw = scrub_gas(src, list(input_gas), input_mix, internal, moles_to_convert)
+	var/power_draw = scrub_gas(src, list(input_gas), input_mix, internal, moles_to_convert, power_rating)
 	if (power_draw > 0)
 		use_power_oneoff(power_draw)
 		last_power_draw += power_draw

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -11,7 +11,7 @@
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 45000	//45000 W ~ 60 HP
+	power_rating = 22500	//22500 W ~ 30 HP
 
 	var/injecting = 0
 

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -15,7 +15,7 @@
 	desc = "Has a valve and pump attached to it."
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 30000			// 30000 W ~ 40 HP
+	power_rating = 15000			// 15000 W ~ 20 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_FUEL //connects to regular, supply pipes, and fuel pipes
 	level = LEVEL_BELOW_PLATING

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -6,7 +6,7 @@
 	desc = "Has a valve and pump attached to it."
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 30000			// 30000 W ~ 40 HP
+	power_rating = 15000			// 15000 W ~ 20 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER //connects to regular and scrubber pipes
 	identifier = "AScr"

--- a/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
@@ -65,7 +65,7 @@
 	// Build list of data from sensor readings.
 	for(var/obj/machinery/power/sensor/S in grid_sensors)
 		sensors.Add(list(list(
-		"name" = S.id_tag,
+		"name" = html_encode(S.id_tag),
 		"alarm" = S.check_grid_warning()
 		)))
 		if(S.id_tag == active_sensor)
@@ -167,5 +167,5 @@
 
 
 	else if( href_list["setsensor"] )
-		active_sensor = href_list["setsensor"]
+		active_sensor = html_decode(href_list["setsensor"])
 		. = 1

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -89,13 +89,13 @@
 			var/obj/item/organ/external/parent = GET_EXTERNAL_ORGAN(src, I.parent_organ)
 			if(parent)
 				var/pain = 10
-				var/message = "You feel a dull pain in your [parent.name]"
+				var/message = "You feel a dull pain in your [parent.name]."
 				if(I.is_bruised())
 					pain = 25
-					message = "You feel a pain in your [parent.name]"
+					message = "You feel a pain in your [parent.name]."
 				if(I.is_broken())
 					pain = 50
-					message = "You feel a sharp pain in your [parent.name]"
+					message = "You feel a sharp pain in your [parent.name]."
 				src.custom_pain(message, pain, affecting = parent)
 
 

--- a/code/modules/power/sensors/powernet_sensor.dm
+++ b/code/modules/power/sensors/powernet_sensor.dm
@@ -37,7 +37,10 @@
 		var/area/A = get_area(src)
 		if(!A)
 			return // in nullspace
-		id_tag = "[A.proper_name] #[sequential_id(A.name + "power/sensor")]"
+		var/suffix = uniqueness_repository.Generate(/datum/uniqueness_generator/id_sequential, "[A.proper_name]power/sensor", 1) // unlike sequential_id, starts at 1 instead of 100
+		if(suffix == 1)
+			suffix = null
+		id_tag = "[A.proper_name][suffix ? " #[suffix]" : null]"
 	name = "[id_tag] - powernet sensor"
 
 // Proc: check_grid_warning()

--- a/code/modules/shield_generators/floor_diffuser.dm
+++ b/code/modules/shield_generators/floor_diffuser.dm
@@ -4,8 +4,8 @@
 	icon = 'icons/obj/machines/shielding.dmi'
 	icon_state = "fdiffuser_on"
 	use_power = POWER_USE_ACTIVE
-	idle_power_usage = 100
-	active_power_usage = 2000
+	idle_power_usage = 25 // Previously 100.
+	active_power_usage = 500 // Previously 2000
 	anchored = TRUE
 	density = FALSE
 	level = LEVEL_BELOW_PLATING

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -514,6 +514,8 @@
 
 	while(HasAbove(T.z))
 		T = GetAbove(T)
+		if(T.z_flags & ZM_TERMINATOR) // Do not propagate from the surface to the station.
+			break
 		if(istype(T))
 			turfs.Add(T)
 
@@ -521,6 +523,8 @@
 
 	while(HasBelow(T.z))
 		T = GetBelow(T)
+		if(T.z_flags & ZM_TERMINATOR) // Or from the station to the surface.
+			break
 		if(istype(T))
 			turfs.Add(T)
 

--- a/maps/tether/atoms/areas.dm
+++ b/maps/tether/atoms/areas.dm
@@ -151,6 +151,7 @@
 	holomap_color = HOLOMAP_AREACOLOR_SECURITY
 
 /area/maintenance
+	name = "\improper Maintenance"
 	area_flags = AREA_FLAG_RAD_SHIELDED
 	sound_env = TUNNEL_ENCLOSED
 	turf_initializer = /decl/turf_initializer/maintenance
@@ -159,11 +160,11 @@
 	holomap_color = HOLOMAP_AREACOLOR_MAINTENANCE
 
 /area/maintenance/bar
-	name = "Bar Maintenance"
+	name = "\improper Bar Maintenance"
 	icon_state = "maint_bar"
 
 /area/maintenance/bar/catwalk
-	name = "Bar Maintenance Catwalk"
+	name = "\improper Bar Maintenance Catwalk"
 	icon_state = "maint_bar"
 
 /area/medical/medbay_emt_bay
@@ -177,7 +178,7 @@
 /area/outpost/research
 	holomap_color = HOLOMAP_AREACOLOR_SCIENCE
 /area/outpost/research/longtermstorage
-	name = "Research Outpost Long-Term Storage"
+	name = "\improper Research Outpost Long-Term Storage"
 
 /area/outpost/research/toxins_misc_lab
 	name = "\improper Research Outpost Toxins Miscellaneous Research"
@@ -274,6 +275,7 @@
 	icon_state = "shuttle2"
 
 /area/shuttle/large_escape_pod1/station
+	name = "\improper Large Escape Pod"
 	icon_state = "shuttle2"
 	base_turf = /turf/exterior/barren
 
@@ -393,7 +395,7 @@
 
 
 /area/tether/surfacebase/outside
-	name = "Outside - Surface"
+	name = "\improper Outside - Surface"
 	sound_env = MOUNTAINS
 	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_BACKGROUND | AREA_FLAG_HIDE_FROM_HOLOMAP
 	is_outside = OUTSIDE_YES
@@ -1341,24 +1343,29 @@
 	name = "\improper Engineering Maintenance"
 	icon_state = "maint_engineering"
 /area/maintenance/engineering/pumpstation
-	name = "Engineering Pump Station"
+	name = "\improper Engineering Pump Station"
 	icon_state = "maint_pumpstation"
 /area/maintenance/evahallway
 	name = "\improper EVA Maintenance"
 	icon_state = "maint_eva"
 	req_access = list(list(access_eva, access_maint_tunnels))
 /area/maintenance/substation/cargo
-	name = "Cargo Substation"
+	name = "\improper Cargo Substation"
+
 /area/maintenance/substation/civilian
+	name = "\improper Civilian Substation"
+
 /area/maintenance/substation/command
+	name = "\improper Command Substation"
+
 /area/maintenance/substation/engineering
-	name = "Engineering Substation"
+	name = "\improper Engineering Substation"
 /area/maintenance/substation/medical
-	name = "Medical Substation"
+	name = "\improper Medical Substation"
 /area/maintenance/substation/research
-	name = "Research Substation"
+	name = "\improper Research Substation"
 /area/maintenance/substation/security
-	name = "Security Substation"
+	name = "\improper Security Substation"
 /area/medical/biostorage
 	name = "\improper Secondary Storage"
 	icon_state = "medbay4"
@@ -1547,6 +1554,7 @@
 
 // Visitor/crew amenities
 /area/bridge
+	name = "\improper Bridge"
 	holomap_color = HOLOMAP_AREACOLOR_COMMAND
 /area/bridge/secondary
 	name = "\improper Secondary Command Office"

--- a/maps/tether/main_dmms/tether-01-surface1.dmm
+++ b/maps/tether/main_dmms/tether-01-surface1.dmm
@@ -36,16 +36,13 @@
 "aad" = (
 /turf/exterior/sif_growth,
 /area/tether/surfacebase/outside/outside1)
-"aae" = (
-/turf/exterior/sif_growth,
-/area/tether/surfacebase/mining_main/external)
 "aaf" = (
 /turf/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
 "aag" = (
 /obj/machinery/hologram/holopad,
 /turf/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/outside/outside1)
 "aah" = (
 /turf/wall/natural,
 /area/tether/surfacebase/outside/outside1)
@@ -53,9 +50,8 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/machinery/shield_diffuser,
 /turf/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/outside/outside1)
 "aaj" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -387,9 +383,8 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/machinery/shield_diffuser,
 /turf/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/outside/outside1)
 "aaX" = (
 /obj/structure/flaps,
 /obj/machinery/conveyor{
@@ -18283,8 +18278,8 @@
 	icon_state = "map_vent_in";
 	id_tag = "atmos_in";
 	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
+	internal_pressure_bound = 400;
+	internal_pressure_bound_default = 400;
 	pressure_checks = 2;
 	pressure_checks_default = 2;
 	pump_direction = 0;
@@ -18502,7 +18497,6 @@
 /obj/machinery/air_sensor{
 	id_tag = "atmos_intake"
 	},
-/obj/machinery/shield_diffuser,
 /turf/floor/tiled/steel_dirty/virgo3b,
 /area/engineering/atmos/intake)
 "aJB" = (
@@ -29702,10 +29696,6 @@
 	},
 /turf/floor/tiled,
 /area/engineering/atmos)
-"cAR" = (
-/obj/machinery/shield_diffuser,
-/turf/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
 "cBB" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -30056,8 +30046,8 @@
 	icon_state = "map_vent_in";
 	id_tag = "atmos_in";
 	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
+	internal_pressure_bound = 400;
+	internal_pressure_bound_default = 400;
 	pressure_checks = 2;
 	pressure_checks_default = 2;
 	pump_direction = 0;
@@ -30265,10 +30255,6 @@
 /obj/machinery/meter,
 /turf/floor/tiled/techmaint,
 /area/engineering/atmos)
-"fOF" = (
-/obj/machinery/shield_diffuser,
-/turf/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
 "fPj" = (
 /obj/structure/closet/secure_closet/paramedic,
 /obj/item/stack/nanopaste,
@@ -38577,10 +38563,10 @@ aah
 aah
 aah
 aah
-pLu
-pLu
-pLu
-pLu
+akb
+akb
+akb
+akb
 aah
 aah
 aah
@@ -41114,7 +41100,7 @@ bOI
 bQT
 aHh
 aIp
-pLu
+akb
 aad
 aad
 aad
@@ -41270,7 +41256,7 @@ bOt
 bQL
 bSJ
 aIq
-pLu
+akb
 aad
 aad
 aad
@@ -41426,7 +41412,7 @@ bON
 bQV
 bSJ
 aIq
-pLu
+akb
 aad
 aad
 aad
@@ -41582,7 +41568,7 @@ bOL
 bQU
 aHh
 aIr
-pLu
+akb
 aad
 aad
 aad
@@ -43466,16 +43452,16 @@ aIv
 aIv
 aIv
 aIv
-cAR
-cAR
-cAR
-cAR
+aJt
+aJt
+aJt
+aJt
 aJA
-cAR
-cAR
-cAR
-cAR
-cAR
+aJt
+aJt
+aJt
+aJt
+aJt
 aad
 aad
 aad
@@ -43632,7 +43618,7 @@ aJS
 aJJ
 aJS
 aJt
-cAR
+aJt
 aad
 aad
 aad
@@ -43788,7 +43774,7 @@ aIM
 aIM
 aIM
 aJS
-cAR
+aJt
 aad
 aad
 aad
@@ -43944,7 +43930,7 @@ aJK
 aJW
 aKl
 aKl
-cAR
+aJt
 aad
 aad
 aad
@@ -44100,7 +44086,7 @@ aJJ
 aJS
 aKl
 aKl
-cAR
+aJt
 aad
 aad
 aad
@@ -44166,7 +44152,7 @@ aad
 aad
 aad
 aad
-pLu
+akb
 aBy
 qQw
 jZV
@@ -44256,7 +44242,7 @@ aIM
 aIM
 aIM
 aJW
-cAR
+aJt
 aad
 aad
 aad
@@ -44322,7 +44308,7 @@ aad
 aad
 aad
 aad
-pLu
+akb
 aDD
 bVO
 den
@@ -44478,7 +44464,7 @@ aad
 aad
 aad
 aad
-pLu
+akb
 aDD
 bVO
 mYW
@@ -44634,7 +44620,7 @@ aad
 aad
 aad
 aad
-pLu
+akb
 cHR
 qQw
 qQw
@@ -46487,25 +46473,25 @@ aaT
 aaT
 aaT
 rmp
-aaf
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-fOF
+akb
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+akb
 aaf
 aao
 aau
@@ -46643,24 +46629,24 @@ aaT
 aaT
 aaT
 rmp
-aaf
-fOF
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+akb
+akb
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aaW
 aaj
 aao
@@ -46799,24 +46785,24 @@ aaT
 aaT
 aaT
 rmp
-aaf
-aaf
-aaf
-fOF
-fOF
-fOF
-fOF
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aai
 vCB
 aap
@@ -46955,25 +46941,25 @@ aaT
 aaT
 aaT
 rmp
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-fOF
-fOF
-fOF
-fOF
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaf
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+akb
 aaf
 aaq
 aax
@@ -47111,25 +47097,25 @@ aaT
 aaT
 aaT
 rmp
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-fOF
-fOF
-fOF
-fOF
-fOF
-fOF
-aaf
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
 aak
 aar
 aar
@@ -47267,25 +47253,25 @@ aaT
 aaT
 aaT
 rmp
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
 aal
 aat
 aaz
@@ -47423,25 +47409,25 @@ aaT
 aaT
 aaT
 rmp
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
 aam
 aas
 aay
@@ -47579,25 +47565,25 @@ aaT
 aaT
 aaT
 rmp
-aaf
-aaf
-aaf
-fOF
-fOF
-fOF
-fOF
-fOF
-fOF
-fOF
-fOF
-fOF
-fOF
-fOF
-fOF
-fOF
-aaf
-aaf
-aaf
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
+akb
 aan
 aar
 aar
@@ -47735,25 +47721,25 @@ aaT
 aaT
 aaT
 rmp
-aaf
-fOF
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaf
+akb
+akb
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+akb
 aag
-aaf
+akb
 aaf
 oDw
 jAw
@@ -47891,25 +47877,25 @@ aaT
 aaT
 aaT
 rmp
-aaf
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-fOF
-fOF
-fOF
+akb
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+akb
+akb
+akb
 aaf
 oDw
 waw
@@ -48066,7 +48052,7 @@ aad
 aad
 aad
 aad
-fOF
+aaf
 uVV
 dcr
 aar

--- a/maps/tether/submaps/engine/engine_sme.dmm
+++ b/maps/tether/submaps/engine/engine_sme.dmm
@@ -402,6 +402,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
 	},
+/obj/machinery/power/terminal{
+	icon_state = "term-omni"
+	},
 /turf/floor/tiled/monotile,
 /area/engineering/engine_room)
 "bc" = (
@@ -673,7 +676,6 @@
 /area/template_noop)
 "bB" = (
 /obj/machinery/computer/air_control/supermatter_core{
-	dir = 1;
 	input_tag = "cooling_in";
 	name = "Engine Cooling Control";
 	output_tag = "cooling_out";


### PR DESCRIPTION
## Description of changes
A bunch of tweaks to power consumption, and some map edits to remove the especially power-hungry machines that weren't actually necessary.

## Why and what will this PR improve
Dramatically lowers power consumption of the Tether, so certain areas don't drain in literal seconds after roundstart.